### PR TITLE
Fix: check of sensor text for valid characters

### DIFF
--- a/bin/user/kl.py
+++ b/bin/user/kl.py
@@ -2618,7 +2618,7 @@ class StationConfig(object):
                         sensor_text = sensor_text[0:10]
                     text_ok = True
                     for y in range(0, len(sensor_text)):
-                        if sensor_text[y:y + 1] in Decode.CHARSTR:
+                        if not sensor_text[y:y + 1] in Decode.CHARSTR:
                             text_ok = False
                             loginf('sensor_text%d: "%s" contains bogus'
                                    ' character %s at position %s' %


### PR DESCRIPTION
I saw that my log file contains messages about bogus characters in sensor texts. It seems to me that the check implemented prevents valid characters instead of invalid ones. I'm not 100% sure because I have no experience in python.